### PR TITLE
Add support for loading models from Mongoid

### DIFF
--- a/lib/nazrin/data_accessor.rb
+++ b/lib/nazrin/data_accessor.rb
@@ -29,6 +29,9 @@ module Nazrin
         if defined?(::ActiveRecord::Base) && clazz.ancestors.include?(::ActiveRecord::Base)
           require 'nazrin/data_accessor/active_record'
           return Nazrin::DataAccessor::ActiveRecord
+        elsif defined?(::Mongoid::Document) && clazz.ancestors.include?(::Mongoid::Document)
+          require 'nazrin/data_accessor/mongoid'
+          return Nazrin::DataAccessor::Mongoid
         end
         nil
       end

--- a/lib/nazrin/data_accessor/mongoid.rb
+++ b/lib/nazrin/data_accessor/mongoid.rb
@@ -1,0 +1,15 @@
+module Nazrin
+  class DataAccessor
+    class Mongoid < Nazrin::DataAccessor
+      def load_all(ids)
+        documents_table = {}
+        @model.where('_id' => { '$in' => ids }).each do |document|
+          documents_table[document._id.to_s] = document
+        end
+        ids.map do |id|
+          documents_table[id]
+        end.reject(&:nil?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, `load_all` does not support loading models from a Mongoid-backed database. It only supports ActiveRecord. This PR adds support for Mongoid records. Let me know if you have better ideas on how to add support for this. 