### PR TITLE
Allow options to be passed to model

### DIFF
--- a/lib/nazrin/data_accessor/mongoid.rb
+++ b/lib/nazrin/data_accessor/mongoid.rb
@@ -3,6 +3,13 @@ module Nazrin
     class Mongoid < Nazrin::DataAccessor
       def load_all(ids)
         documents_table = {}
+        @options.each do |k, v|
+          @model = if v.nil?
+                     @model.send(k)
+                   else
+                     @model.send(k, v)
+                   end
+        end
         @model.where('_id' => { '$in' => ids }).each do |document|
           documents_table[document._id.to_s] = document
         end


### PR DESCRIPTION
This lets you pass things like `Person.search(includes: :name, unscoped: nil)`.