### PR TITLE
Support multiple domains

### DIFF
--- a/lib/nazrin.rb
+++ b/lib/nazrin.rb
@@ -1,6 +1,7 @@
 require 'aws-sdk-cloudsearchdomain'
 
 require 'nazrin/searchable'
+require 'nazrin/searchable/config'
 require 'nazrin/data_accessor'
 require 'nazrin/config'
 require 'nazrin/search_client'

--- a/lib/nazrin/document_client.rb
+++ b/lib/nazrin/document_client.rb
@@ -2,12 +2,12 @@ module Nazrin
   class DocumentClient
     attr_reader :client
 
-    def initialize
+    def initialize(config=Nazrin.config)
       @client = Aws::CloudSearchDomain::Client.new(
-        endpoint: Nazrin.config.document_endpoint,
-        region: Nazrin.config.region,
-        access_key_id: Nazrin.config.access_key_id,
-        secret_access_key: Nazrin.config.secret_access_key)
+        endpoint: config.document_endpoint,
+        region: config.region,
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key)
     end
 
     def add_document(id, field_data)

--- a/lib/nazrin/search_client.rb
+++ b/lib/nazrin/search_client.rb
@@ -7,13 +7,13 @@ module Nazrin
     attr_accessor :data_accessor
     attr_reader :parameters
 
-    def initialize
+    def initialize(config=Nazrin.config)
       # @see http://docs.aws.amazon.com/sdkforruby/api/Aws/CloudSearchDomain/Client.html aws-sdk
       @client = Aws::CloudSearchDomain::Client.new(
-        endpoint: Nazrin.config.search_endpoint,
-        region: Nazrin.config.region,
-        access_key_id: Nazrin.config.access_key_id,
-        secret_access_key: Nazrin.config.secret_access_key)
+        endpoint: config.search_endpoint,
+        region: config.region,
+        access_key_id: config.access_key_id,
+        secret_access_key: config.secret_access_key)
       @parameters = {}
     end
 

--- a/lib/nazrin/searchable.rb
+++ b/lib/nazrin/searchable.rb
@@ -29,11 +29,12 @@ module Nazrin
           alias_method :searchable, :nazrin_searchable unless method_defined? :searchable
           alias_method :fields, :nazrin_fields unless method_defined? :fields
           alias_method :field, :nazrin_field unless method_defined? :field
+          alias_method :searchable_configure, :nazrin_searchable_configure unless method_defined? :searchable_configure
         end
       end
 
       def nazrin_search(options = {})
-        client = Nazrin::SearchClient.new
+        client = Nazrin::SearchClient.new(nazrin_searchable_config)
         client.data_accessor = Nazrin::DataAccessor.for(self).new(self, options)
         client
       end
@@ -41,7 +42,7 @@ module Nazrin
       def nazrin_searchable(&block)
         class_variable_set(
           :@@nazrin_doc_client,
-          Nazrin::DocumentClient.new)
+          Nazrin::DocumentClient.new(nazrin_searchable_config))
         class_variable_set(:@@nazrin_search_field_data, {})
         block.call
       end
@@ -86,6 +87,14 @@ module Nazrin
 
       def nazrin_delete_document(obj)
         nazrin_doc_client.delete_document(obj.send(:id))
+      end
+
+      def nazrin_searchable_config
+        @nazrin_searchable_config ||= Nazrin::Searchable::Configuration.new
+      end
+
+      def nazrin_searchable_configure
+        yield nazrin_searchable_config
       end
     end
   end

--- a/lib/nazrin/searchable/config.rb
+++ b/lib/nazrin/searchable/config.rb
@@ -1,0 +1,23 @@
+module Nazrin
+  module Searchable
+    class Configuration
+      %i(
+        search_endpoint
+        document_endpoint
+        region
+        access_key_id
+        secret_access_key
+      ).each do |attr|
+        class_eval <<-CODE, __FILE__, __LINE__ + 1
+          def #{attr}
+            @#{attr} || Nazrin.config.#{attr}
+          end
+
+          def #{attr}=(v)
+            @#{attr} = v
+          end
+        CODE
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, `nazrin` supports only one search endpoint configured via `Nazrin.configure`.
With this change, you can override `Nazrin.config` in a model class which includes `Nazrin::Searchable`.
This is useful when you have separated search domains per model.