### PR TITLE
Add Nazrin::DataAccessor::Struct

### DIFF
--- a/lib/nazrin/data_accessor/active_record.rb
+++ b/lib/nazrin/data_accessor/active_record.rb
@@ -4,15 +4,19 @@ module Nazrin
       # load from activerecord
       def load_all(ids)
         records_table = {}
-        @options.each do |k, v|
-          @model = @model.send(k, v)
+        options.each do |k, v|
+          model = model.send(k, v)
         end
-        @model.where(id: ids).each do |record|
+        model.where(id: ids).each do |record|
           records_table[record.id] = record
         end
         ids.map do |id|
           records_table.select { |k, _| k == id.to_i }[id.to_i]
         end.reject(&:nil?)
+      end
+
+      def data_from_response(res)
+        res.data.hits.hit.map(&:id)
       end
     end
   end

--- a/lib/nazrin/data_accessor/mongoid.rb
+++ b/lib/nazrin/data_accessor/mongoid.rb
@@ -3,19 +3,23 @@ module Nazrin
     class Mongoid < Nazrin::DataAccessor
       def load_all(ids)
         documents_table = {}
-        @options.each do |k, v|
-          @model = if v.nil?
-                     @model.send(k)
+        options.each do |k, v|
+          model = if v.nil?
+                     model.send(k)
                    else
-                     @model.send(k, v)
+                     model.send(k, v)
                    end
         end
-        @model.where('_id' => { '$in' => ids }).each do |document|
+        model.where('_id' => { '$in' => ids }).each do |document|
           documents_table[document._id.to_s] = document
         end
         ids.map do |id|
           documents_table[id]
         end.reject(&:nil?)
+      end
+
+      def data_from_response(res)
+        res.data.hits.hit.map(&:id)
       end
     end
   end

--- a/lib/nazrin/data_accessor/struct.rb
+++ b/lib/nazrin/data_accessor/struct.rb
@@ -1,0 +1,68 @@
+require 'aws-sdk-cloudsearch'
+
+module Nazrin
+  class DataAccessor
+    class Struct < Nazrin::DataAccessor
+      class MissingDomainNameConfigError < StandardError; end
+
+      class << self
+        attr_reader :config
+
+        def [](config)
+          Class.new(self).tap do |clazz|
+            clazz.instance_variable_set(:@config, config)
+          end
+        end
+
+        def transform_attributes(attributes)
+          attributes.each_with_object({}) do |(name, value), hash|
+            type = field_types[name]
+
+            if type.end_with?('array')
+              hash[name] = value
+            else
+              hash[name] = value.first
+            end
+          end
+        end
+
+        def field_types
+          return @field_types if defined?(@field_types)
+
+          response = cloudsearch_client.describe_index_fields(
+            domain_name: config.domain_name
+          )
+
+          @field_types = response.index_fields.each_with_object({}) do |field, fields|
+            name = field.options[:index_field_name]
+            type = field.options[:index_field_type]
+
+            fields[name] = type
+          end
+        end
+
+        private
+
+        def cloudsearch_client
+          @cloudsearch_client ||= Aws::CloudSearch::Client.new(
+            access_key_id: config.access_key_id,
+            secret_access_key: config.secret_access_key,
+            logger: config.logger
+          )
+        end
+      end
+
+      def load_all(data)
+        data.map do |attributes|
+          model.new(attributes)
+        end
+      end
+
+      def data_from_response(res)
+        res.data[:hits][:hit].map do |hit|
+          self.class.transform_attributes(hit[:fields])
+        end
+      end
+    end
+  end
+end

--- a/lib/nazrin/searchable/config.rb
+++ b/lib/nazrin/searchable/config.rb
@@ -1,6 +1,8 @@
 module Nazrin
   module Searchable
     class Configuration
+      attr_accessor :domain_name
+
       %i(
         search_endpoint
         document_endpoint

--- a/nazrin.gemspec
+++ b/nazrin.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'aws-sdk-core', '~> 3'
+  spec.add_dependency 'aws-sdk-cloudsearch', '~> 1.0'
   spec.add_dependency 'aws-sdk-cloudsearchdomain', '~> 1.0'
   spec.add_dependency 'activesupport', '>= 4.0.0'
 

--- a/spec/nazrin/data_accessor/struct_spec.rb
+++ b/spec/nazrin/data_accessor/struct_spec.rb
@@ -1,0 +1,110 @@
+require 'spec_helper'
+
+describe Nazrin::DataAccessor::Struct do
+  let(:clazz) do
+    Class.new do
+      def self.name; 'CustomStruct'; end
+      include Nazrin::Searchable
+
+      attr_reader :attributes
+
+      searchable_configure do |config|
+        config.domain_name = 'my-domain-name'
+      end
+
+      def initialize(attributes)
+        @attributes = attributes
+      end
+    end
+  end
+  let(:data_accessor) { Nazrin::DataAccessor.for(clazz) }
+
+  it do
+    expect(data_accessor).to be < Nazrin::DataAccessor::Struct
+  end
+
+  describe '.field_types' do
+    let(:cs_client) do
+      instance_double(Aws::CloudSearch::Client)
+    end
+    let(:index_fields_response) { double(index_fields: index_fields) }
+    let(:index_fields) do
+      [id_field, name_field, tags_field]
+    end
+    let(:id_field) do
+      double(
+        options: {
+          index_field_name: 'id',
+          index_field_type: 'int'
+        }
+      )
+    end
+    let(:name_field) do
+      double(
+        options: {
+          index_field_name: 'name',
+          index_field_type: 'text'
+        }
+      )
+    end
+    let(:tags_field) do
+      double(
+        options: {
+          index_field_name: 'tags',
+          index_field_type: 'literal-array'
+        }
+      )
+    end
+
+    before do
+      allow(Aws::CloudSearch::Client).to receive(:new).and_return(
+        cs_client
+      )
+      allow(cs_client).to receive(:describe_index_fields).and_return(
+        index_fields_response
+      )
+    end
+
+    it do
+      expect(Aws::CloudSearch::Client).to receive(:new).with(
+        access_key_id: Nazrin.config.access_key_id,
+        secret_access_key: Nazrin.config.secret_access_key,
+        logger: Nazrin.config.logger
+      )
+      expect(cs_client).to receive(:describe_index_fields).with(
+        domain_name: 'my-domain-name'
+      )
+      expect(data_accessor.field_types).to eq(
+        'id' => 'int',
+        'name' => 'text',
+        'tags' => 'literal-array'
+      )
+    end
+  end
+
+  describe '.transform_attributes' do
+    let(:attributes) do
+      {
+        'id' => ['1'],
+        'name' => ['Michael'],
+        'tags' => ['one', 'two', 'three']
+      }
+    end
+
+    before do
+      allow(data_accessor).to receive(:field_types).and_return(
+        'id' => 'int',
+        'name' => 'text',
+        'tags' => 'literal-array'
+      )
+    end
+
+    it do
+      expect(data_accessor.transform_attributes(attributes)).to eq(
+        'id' => '1',
+        'name' => 'Michael',
+        'tags' => ['one', 'two', 'three']
+      )
+    end
+  end
+end

--- a/spec/nazrin/struct/searchable_spec.rb
+++ b/spec/nazrin/struct/searchable_spec.rb
@@ -1,0 +1,75 @@
+describe Nazrin::Searchable do
+  let(:clazz) do
+    Class.new do
+      def self.name; 'CustomStruct'; end
+      include Nazrin::Searchable
+
+      attr_reader :attributes
+
+      searchable_configure do |config|
+        config.domain_name = 'my-domain-name'
+      end
+
+      def initialize(attributes)
+        @attributes = attributes
+      end
+    end
+  end
+  let(:data_accessor) { Nazrin::DataAccessor.for(clazz) }
+
+  describe '#search' do
+    let(:result) do
+      clazz.search.query_parser('structured').query('matchall').execute
+    end
+    let(:fake_response) do
+      double(
+        data: {
+          hits: {
+            hit: [
+              {
+                fields: {
+                  'id' => ['1'],
+                  'name' => ['Michael'],
+                  'tags' => ['one', 'two', 'three']
+                }
+              },
+              {
+                fields: {
+                  'id' => ['2'],
+                  'name' => ['Florence'],
+                  'tags' => ['four', 'five']
+                }
+              }
+            ]
+          }
+        }
+      )
+    end
+    before do
+      allow(data_accessor).to receive(:field_types).and_return(
+        'id' => 'int',
+        'name' => 'text',
+        'tags' => 'literal-array'
+      )
+      allow_any_instance_of(Nazrin::SearchClient).to receive(:search).and_return(
+        fake_response
+      )
+    end
+
+    it { expect(result.length).to eq(2) }
+    it do
+      expect(result[0].attributes).to eq(
+        'id' => '1',
+        'name' => 'Michael',
+        'tags' => ['one', 'two', 'three']
+      )
+    end
+    it do
+      expect(result[1].attributes).to eq(
+        'id' => '2',
+        'name' => 'Florence',
+        'tags' => ['four', 'five']
+      )
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a `Struct` data-accessor, if the class that includes `Nazrin::Searchable` AND defines a `domain_name` config, the schema will be read using an AWS-Cloudsearch `describe_index_fields` call and data will be loaded from Cloudsearch and injected into the constructor when a search is made.

#### Example:

```ruby
class User
  include Nazrin::Searchable

  searchable_configure do |config|
    config.domain_name = 'my-users-domain'
  end

  def initialize(attributes)
    @attributes = attributes
  end
end

User.search.query_parser('structured').query('matchall').execute
```

The schema is read and transformed into a mapping which looks like:
```
{
  'id' => 'int',
  'name' => 'text',
  'permissions' => 'literal-array'
}
```

If the response looks like:
```
{
  'data' => {
    'hits' => {
      'hit' => [
        {
          'id' => '1',
          'fields' => {
            'id' => ['1'],
            'name' => ['Joan'],
            'permissions' => ['admin']
          }
        }
      ]
    }
  }
}
```
It will result in a call like:

`User.new('id' => '1', 'name' => 'Joan', 'permissions' => ['admin'])`