### PR TITLE
Add batch operations

### DIFF
--- a/lib/nazrin/document_client.rb
+++ b/lib/nazrin/document_client.rb
@@ -55,7 +55,7 @@ module Nazrin
             )
           end
         when :delete, :destroy
-          tuple.map do |id|
+          tuple.each do |id|
             arr.push(
               type: 'delete',
               id: id

--- a/lib/nazrin/document_client.rb
+++ b/lib/nazrin/document_client.rb
@@ -46,7 +46,7 @@ module Nazrin
 
       documents = operations.each_with_object([]) do |(type, tuple), arr|
         case type.to_sym
-        when :add, :create
+        when :add
           tuple.each do |id, field_data|
             arr.push(
               type: 'add',
@@ -54,7 +54,7 @@ module Nazrin
               fields: field_data
             )
           end
-        when :delete, :destroy
+        when :delete
           tuple.each do |id|
             arr.push(
               type: 'delete',

--- a/lib/nazrin/document_client.rb
+++ b/lib/nazrin/document_client.rb
@@ -37,5 +37,34 @@ module Nazrin
         ].to_json,
         content_type: 'application/json')
     end
+
+    def batch(operations)
+      ActiveSupport::Deprecation.warn 'config.debug_mode is deprecated. Use config.mode = \'sandbox\' instead.' and return nil if Nazrin.config.debug_mode
+      return nil if Nazrin.config.mode == 'sandbox'
+
+      documents = operations.each_with_object([]) do |(type, tuple), arr|
+        if type.to_sym == :add
+          tuple.each do |id, field_data|
+            arr.push(
+              type: 'add',
+              id: id,
+              fields: field_data
+            )
+          end
+        else
+          tuple.map do |id|
+            arr.push(
+              type: 'delete',
+              id: id
+            )
+          end
+        end
+      end
+
+      client.upload_documents(
+        documents: documents.to_json,
+        content_type: 'application/json'
+      )
+    end
   end
 end

--- a/lib/nazrin/searchable.rb
+++ b/lib/nazrin/searchable.rb
@@ -2,6 +2,8 @@ require 'active_support/concern'
 
 module Nazrin
   module Searchable
+    class InvalidBatchOperationError < StandardError; end
+
     extend ActiveSupport::Concern
 
     included do
@@ -27,6 +29,7 @@ module Nazrin
         class << base
           alias_method :search, :nazrin_search unless method_defined? :search
           alias_method :searchable, :nazrin_searchable unless method_defined? :searchable
+          alias_method :batch_operation, :nazrin_batch_operation unless method_defined? :batch_operation
           alias_method :fields, :nazrin_fields unless method_defined? :fields
           alias_method :field, :nazrin_field unless method_defined? :field
           alias_method :searchable_configure, :nazrin_searchable_configure unless method_defined? :searchable_configure
@@ -45,6 +48,28 @@ module Nazrin
           Nazrin::DocumentClient.new(nazrin_searchable_config))
         class_variable_set(:@@nazrin_search_field_data, {})
         block.call
+      end
+
+      def nazrin_batch_operation(type_objects_mapping)
+        operations = type_objects_mapping.each_with_object({}) do |(type, objects), hash|
+          case type.to_sym
+          when :add, :create
+            hash[:add] = objects.map do |obj|
+              [obj.send(:id), nazrin_eval_field_data(obj)]
+            end
+          when :delete, :destroy
+            hash[:delete] = objects.map do |obj|
+              obj.send(:id)
+            end
+          else
+            raise(
+              InvalidBatchOperationError,
+              "`#{type}` is not a valid batch operation"
+            )
+          end
+        end
+
+        nazrin_doc_client.batch(operations)
       end
 
       def nazrin_fields(fields)
@@ -79,22 +104,6 @@ module Nazrin
       def nazrin_add_document(obj)
         nazrin_doc_client.add_document(
           obj.send(:id), nazrin_eval_field_data(obj))
-      end
-
-      def nazrin_batch_operation(type_objects_mapping)
-        operations = type_objects_mapping.each_with_object({}) do |(type, objects), hash|
-          if type.to_sym == :add
-            hash[:add] = objects.map do |obj|
-              [obj.send(:id), nazrin_eval_field_data(obj)]
-            end
-          else
-            hash[:delete] = objects.map do |obj|
-              obj.send(:id)
-            end
-          end
-        end
-
-        nazrin_doc_client.batch(operations)
       end
 
       def nazrin_update_document(obj)

--- a/lib/nazrin/searchable.rb
+++ b/lib/nazrin/searchable.rb
@@ -53,11 +53,11 @@ module Nazrin
       def nazrin_batch_operation(type_objects_mapping)
         operations = type_objects_mapping.each_with_object({}) do |(type, objects), hash|
           case type.to_sym
-          when :add, :create
+          when :add
             hash[:add] = objects.map do |obj|
               [obj.send(:id), nazrin_eval_field_data(obj)]
             end
-          when :delete, :destroy
+          when :delete
             hash[:delete] = objects.map do |obj|
               obj.send(:id)
             end

--- a/lib/nazrin/searchable.rb
+++ b/lib/nazrin/searchable.rb
@@ -81,6 +81,22 @@ module Nazrin
           obj.send(:id), nazrin_eval_field_data(obj))
       end
 
+      def nazrin_batch_operation(type_objects_mapping)
+        operations = type_objects_mapping.each_with_object({}) do |(type, objects), hash|
+          if type.to_sym == :add
+            hash[:add] = objects.map do |obj|
+              [obj.send(:id), nazrin_eval_field_data(obj)]
+            end
+          else
+            hash[:delete] = objects.map do |obj|
+              obj.send(:id)
+            end
+          end
+        end
+
+        nazrin_doc_client.batch(operations)
+      end
+
       def nazrin_update_document(obj)
         nazrin_add_document(obj)
       end

--- a/spec/nazrin/active_record/searchable_spec.rb
+++ b/spec/nazrin/active_record/searchable_spec.rb
@@ -10,6 +10,65 @@ describe Nazrin::Searchable do
   it { expect(post).to be_respond_to :update_in_index }
   it { expect(post).to be_respond_to :delete_from_index }
 
+  describe '.nazrin_batch_operation' do
+    let!(:other_post) { Post.create(content: 'other', created_at: Time.now) }
+    let!(:deleted_post) { Post.create(content: 'deleted', created_at: Time.now) }
+    let(:domain_client) do
+      instance_double(Aws::CloudSearchDomain::Client)
+    end
+
+    before do
+      allow(Aws::CloudSearchDomain::Client).to receive(:new)
+        .and_return(domain_client)
+      allow(domain_client).to receive(:upload_documents)
+
+      # Hacky method to reset CS domain client
+      Post.class_eval do
+        searchable  do
+          fields [:content]
+          field(:created_at) { created_at.utc.iso8601 }
+        end
+      end
+    end
+
+    subject do
+      Post.nazrin_batch_operation(
+        add: [post, other_post],
+        delete: [deleted_post]
+      )
+    end
+
+    it do
+      expect(domain_client).to receive(:upload_documents).with(
+        documents: [
+          {
+            type: 'add',
+            id: post.id,
+            fields: {
+              content: post.content,
+              created_at: post.created_at.utc.iso8601
+            }
+          },
+          {
+            type: 'add',
+            id: other_post.id,
+            fields: {
+              content: other_post.content,
+              created_at: other_post.created_at.utc.iso8601
+            }
+          },
+          {
+            type: 'delete',
+            id: deleted_post.id
+          }
+        ].to_json,
+        content_type: 'application/json'
+      )
+
+      subject
+    end
+  end
+
   describe '#search' do
     let(:response) { FakeResponse.new }
     before { allow_any_instance_of(Nazrin::SearchClient).to receive(:search).and_return(response) }

--- a/spec/nazrin/nazrin_spec.rb
+++ b/spec/nazrin/nazrin_spec.rb
@@ -7,9 +7,9 @@ describe Nazrin do
     it { expect(config.mode).to eq 'sandbox' }
     it { expect(config.search_endpoint).to eq 'http://search.com' }
     it { expect(config.document_endpoint).to eq 'http://document.com' }
-    it { expect(config.region).to eq :region }
-    it { expect(config.access_key_id).to eq :access_key_id }
-    it { expect(config.secret_access_key).to eq :secret_access_key }
+    it { expect(config.region).to eq 'region' }
+    it { expect(config.access_key_id).to eq 'access_key_id' }
+    it { expect(config.secret_access_key).to eq 'secret_access_key' }
     it { expect(config.logger).to be nil }
   end
 end

--- a/spec/nazrin/struct/searchable_spec.rb
+++ b/spec/nazrin/struct/searchable_spec.rb
@@ -1,3 +1,5 @@
+require 'spec_helper'
+
 describe Nazrin::Searchable do
   let(:clazz) do
     Class.new do
@@ -16,6 +18,83 @@ describe Nazrin::Searchable do
     end
   end
   let(:data_accessor) { Nazrin::DataAccessor.for(clazz) }
+
+  describe '.nazrin_batch_operation' do
+    let(:clazz) do
+      Class.new(super()) do
+        %i(id content created_at).each do |attr|
+          define_method(attr) { attributes[attr] }
+        end
+      end
+    end
+    let(:added_struct_1) do
+      clazz.new(id: 1, content: 'added_1', created_at: Time.now)
+    end
+    let(:added_struct_2) do
+      clazz.new(id: 2, content: 'added_2', created_at: Time.now)
+    end
+    let(:deleted_struct_1) do
+      clazz.new(id: 3, content: 'deleted_1', created_at: Time.now)
+    end
+    let(:domain_client) do
+      instance_double(Aws::CloudSearchDomain::Client)
+    end
+
+    before do
+      allow(data_accessor).to receive(:field_types).and_return(
+        'id' => 'int',
+        'content' => 'text',
+        'created_at' => 'date'
+      )
+      allow(Aws::CloudSearchDomain::Client).to receive(:new)
+        .and_return(domain_client)
+      allow(domain_client).to receive(:upload_documents)
+      # Hacky method to reset CS domain client
+      clazz.class_eval do
+        searchable  do
+          fields [:content]
+          field(:created_at) { created_at.utc.iso8601 }
+        end
+      end
+    end
+
+    subject do
+      clazz.nazrin_batch_operation(
+        add: [added_struct_1, added_struct_2],
+        delete: [deleted_struct_1]
+      )
+    end
+
+    it do
+      expect(domain_client).to receive(:upload_documents).with(
+        documents: [
+          {
+            type: 'add',
+            id: added_struct_1.id,
+            fields: {
+              content: added_struct_1.content,
+              created_at: added_struct_1.created_at.utc.iso8601
+            }
+          },
+          {
+            type: 'add',
+            id: added_struct_2.id,
+            fields: {
+              content: added_struct_2.content,
+              created_at: added_struct_2.created_at.utc.iso8601
+            }
+          },
+          {
+            type: 'delete',
+            id: deleted_struct_1.id
+          }
+        ].to_json,
+        content_type: 'application/json'
+      )
+
+      subject
+    end
+  end
 
   describe '#search' do
     let(:result) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -12,9 +12,9 @@ Nazrin.configure do |config|
   config.mode = 'production'
   config.search_endpoint = 'http://search.com'
   config.document_endpoint = 'http://document.com'
-  config.region = :region
-  config.access_key_id = :access_key_id
-  config.secret_access_key = :secret_access_key
+  config.region = 'region'
+  config.access_key_id = 'access_key_id'
+  config.secret_access_key = 'secret_access_key'
 end
 
 class FakeResponse


### PR DESCRIPTION
#### Example:

```ruby
class User < ActiveRecord::Base
  include Nazrin::Searchable

  searchable_configure do |config|
    # My config
  end

  searchable do
    fields [:name, :email]
  end
end
# Create some users
user_1 = User.create(name: 'Jane', email: 'no-reply@jane-fake-email.com')
user_2 = User.create(name: 'Joe', email: 'no-reply@joe-fake-email.com')
user_3 = User.create(name: 'John', email: 'no-reply@john-fake-email.com')
# Delete a user
user_3.destroy

User.nazrin_batch_operation(
  add: [user_1, user_2],
  delete: [user_3]
)
```