### PR TITLE
Fixed bug that undefined method xxx for nil:NilClass when options given to search

### DIFF
--- a/lib/nazrin/data_accessor/active_record.rb
+++ b/lib/nazrin/data_accessor/active_record.rb
@@ -5,7 +5,7 @@ module Nazrin
       def load_all(ids)
         records_table = {}
         options.each do |k, v|
-          model = model.send(k, v)
+          @model = model.send(k, v)
         end
         model.where(id: ids).each do |record|
           records_table[record.id] = record

--- a/lib/nazrin/data_accessor/mongoid.rb
+++ b/lib/nazrin/data_accessor/mongoid.rb
@@ -4,7 +4,7 @@ module Nazrin
       def load_all(ids)
         documents_table = {}
         options.each do |k, v|
-          model = if v.nil?
+          @model = if v.nil?
                      model.send(k)
                    else
                      model.send(k, v)

--- a/spec/nazrin/data_accessor/mongoid_spec.rb
+++ b/spec/nazrin/data_accessor/mongoid_spec.rb
@@ -22,5 +22,9 @@ describe 'Nazrin::DataAccessor::Mongoid' do
       it { expect(User.search.size(1).start(0).execute).to eq [user] }
       it { expect(User.search.size(1).start(0).execute.facets).to eq(response.facets) }
     end
+
+    context 'with options' do
+      it { expect(User.search({in: {email: ['example@example.com']}}).size(1).start(0).execute).to eq [user] }
+    end
   end
 end

--- a/spec/nazrin/data_accessor/mongoid_spec.rb
+++ b/spec/nazrin/data_accessor/mongoid_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Nazrin::DataAccessor::Mongoid do
+describe 'Nazrin::DataAccessor::Mongoid' do
   let!(:user) { User.create(email: 'example@example.com', created_at: Time.now) }
 
   it { expect(User).to be_respond_to :search }

--- a/spec/nazrin/data_accessor/struct_spec.rb
+++ b/spec/nazrin/data_accessor/struct_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe Nazrin::DataAccessor::Struct do
+describe 'Nazrin::DataAccessor::Struct' do
   let(:clazz) do
     Class.new do
       def self.name; 'CustomStruct'; end


### PR DESCRIPTION
fixes #32 

1. fixed the left side `model` to `@model`. If we use `model` on the left side, `model` is defined as new local variable, and we cannot reference `model` instance method without `self`.

2. fixed `describe` arguments, because these constants are not loaded, and raises error since ruby 2.3.
 
