### PR TITLE
Pass region to cloudsearch client in Nazrin::DataAccessor::Struct

### DIFF
--- a/lib/nazrin/data_accessor/struct.rb
+++ b/lib/nazrin/data_accessor/struct.rb
@@ -45,6 +45,7 @@ module Nazrin
 
         def cloudsearch_client
           @cloudsearch_client ||= Aws::CloudSearch::Client.new(
+            region: config.region,
             access_key_id: config.access_key_id,
             secret_access_key: config.secret_access_key,
             logger: config.logger

--- a/spec/nazrin/data_accessor/struct_spec.rb
+++ b/spec/nazrin/data_accessor/struct_spec.rb
@@ -67,6 +67,7 @@ describe 'Nazrin::DataAccessor::Struct' do
 
     it do
       expect(Aws::CloudSearch::Client).to receive(:new).with(
+        region: Nazrin.config.region,
         access_key_id: Nazrin.config.access_key_id,
         secret_access_key: Nazrin.config.secret_access_key,
         logger: Nazrin.config.logger


### PR DESCRIPTION
Previously this just relied on the AWS_REGION environment variable or config from ~/.aws/config