### PR TITLE
Add support for highlight search option in struct

### DIFF
--- a/lib/nazrin/data_accessor/struct.rb
+++ b/lib/nazrin/data_accessor/struct.rb
@@ -1,9 +1,12 @@
 require 'nazrin/data_accessor/struct/attribute_transformer'
+require 'active_support/core_ext/hash/except'
 
 module Nazrin
   class DataAccessor
     class Struct < Nazrin::DataAccessor
       class MissingDomainNameConfigError < StandardError; end
+
+      NAZRIN_HIGHLIGHTS_ITEM_KEY = 'highlights___'
 
       class << self
         attr_reader :config
@@ -27,14 +30,20 @@ module Nazrin
 
       def load_all(data)
         data.map do |attributes|
-          model.new(attributes)
+          model.new(attributes.except(NAZRIN_HIGHLIGHTS_ITEM_KEY)).tap do |instance|
+            instance.nazrin_highlights = ActiveSupport::OrderedOptions[attributes[NAZRIN_HIGHLIGHTS_ITEM_KEY].transform_keys(&:to_sym)]
+          end
         end
       end
 
       def data_from_response(res)
         res.data[:hits][:hit].map do |hit|
           self.class.attribute_transformer.call(
-            { 'id' => hit[:id] }.merge(hit[:fields] || {})
+            { 'id' => hit[:id] }.merge(
+              hit[:fields] || {}
+            ).merge(
+              { NAZRIN_HIGHLIGHTS_ITEM_KEY => hit[:highlights] || {} }
+            )
           )
         end
       end

--- a/lib/nazrin/data_accessor/struct/attribute_transformer.rb
+++ b/lib/nazrin/data_accessor/struct/attribute_transformer.rb
@@ -21,7 +21,7 @@ module Nazrin
           attributes.each_with_object({}) do |(name, value), hash|
             type = field_types[name]
 
-            if type.end_with?('array')
+            if type.nil? || type.end_with?('array')
               hash[name] = value
             else
               hash[name] = value.first

--- a/lib/nazrin/searchable.rb
+++ b/lib/nazrin/searchable.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require 'active_support/core_ext/module/aliasing'
 
 module Nazrin
   module Searchable
@@ -10,6 +11,9 @@ module Nazrin
       alias_method :delete_from_index, :nazrin_delete_from_index unless method_defined? :delete_from_index
       alias_method :add_to_index, :nazrin_add_to_index unless method_defined? :add_to_index
       alias_method :update_in_index, :nazrin_update_in_index unless method_defined? :update_in_index
+
+      attr_accessor :nazrin_highlights
+      alias_attribute :highlights, :nazrin_highlights unless method_defined? :highlights
     end
 
     def nazrin_delete_from_index


### PR DESCRIPTION
I supported highlight search option using struct pattern.

```ruby
result = Movie.search.query('movie').highlight({title: {format: 'text'}}.to_json).execute
result.first.highlights.title
# => Extreme *Movie*
```

I didn't add anything to the README because I didn't know what to add.

### TODO

- [ ] Update README